### PR TITLE
Fix typo in manifest

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,3 @@
 include LICENSE
 include example.ini
-inclide tox.ini
+include tox.ini


### PR DESCRIPTION
Happened to see this warning while looking at a [doc build](https://readthedocs.org/api/v2/build/11508632.txt) for pytest.