### PR TITLE
add version to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,7 @@ def main():
         readme = fp.read()
     setup(
         name='iniconfig',
+        version='1.0.1',
         py_modules=['iniconfig'],
         description='iniconfig: brain-dead simple config-ini parsing',
         long_description=readme,


### PR DESCRIPTION
I was using a Python dependency management tool (pypi2nix) that complained about a missing version field in `setup.py`. Looking around it seems like standard practice to include one of these. This PR simply adds a version field that matches the current release version.