### PR TITLE
Fix version autodetection from git tags

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,7 @@ def main():
         package_dir={'': 'src'},
         description='iniconfig: brain-dead simple config-ini parsing',
         long_description=readme,
+        use_scm_version=True,
         url='http://github.com/RonnyPfannschmidt/iniconfig',
         license='MIT License',
         platforms=['unix', 'linux', 'osx', 'cygwin', 'win32'],


### PR DESCRIPTION
Fixes #14 (provided a new release of this package to PyPI)

#10 dropped the `setup_requires` option by moving build requirements to `pyproject.toml`. Sounds fair enough, but #10 _also_ dropped `use_scm_version`, while the versioning strategy hasn't changed (at least, there's no explicit `version` option passed to `setup()`). So it looks like it was an oversight, and this PR adds the option back.