### PR TITLE
Deploy to TestPyPI for master and production PyPI for tags

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,58 @@
+name: Deploy
+
+on:
+  push:
+    branches:
+      - master
+  release:
+    types:
+      - published
+
+jobs:
+  build:
+    if: github.repository == 'RonnyPfannschmidt/iniconfig'
+    runs-on: ubuntu-20.04
+
+    steps:
+      - uses: actions/checkout@v2
+      - run: |
+            git fetch --prune --unshallow
+
+      - name: Cache
+        uses: actions/cache@v2
+        with:
+          path: ~/.cache/pip
+          key: deploy-${{ hashFiles('**/setup.py') }}
+          restore-keys: |
+            deploy-
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.9
+
+      - name: Install dependencies
+        run: |
+          python -m pip install -U pip
+          python -m pip install -U setuptools twine wheel
+
+      - name: Build package
+        run: |
+          git tag
+          python setup.py --version
+          python setup.py sdist --format=gztar bdist_wheel
+          twine check dist/*
+
+      - name: Publish package to PyPI
+        if: github.event.action == 'published'
+        uses: pypa/gh-action-pypi-publish@master
+        with:
+          user: __token__
+          password: ${{ secrets.pypi_password }}
+
+      - name: Publish package to TestPyPI
+        uses: pypa/gh-action-pypi-publish@master
+        with:
+          user: __token__
+          password: ${{ secrets.test_pypi_password }}
+          repository_url: https://test.pypi.org/legacy/

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,7 +30,7 @@ jobs:
         python-version: ${{ matrix.python }}
     - name: Install tox
       run: |
-        python -m pip install --upgrade pip setuptools
+        python -m pip install --upgrade pip setuptools setuptools_scm
         pip install tox
     - name: Test
       run: |

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,6 +25,4 @@ requires_python = >=3.5
 packages = iniconfig
 include_package_data = True
 package_dir = =src
-setup_requires =
-    setuptools_scm
 zip_safe = False

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,4 +25,6 @@ requires_python = >=3.5
 packages = iniconfig
 include_package_data = True
 package_dir = =src
+setup_requires =
+    setuptools_scm
 zip_safe = False

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,10 @@
 from setuptools import setup
 
-setup(use_scm_version=True)
+
+def local_scheme(version):
+    """Skip the local version (eg. +xyz of 0.6.1.dev4+gdf99fe2)
+    to be able to upload to Test PyPI"""
+    return ""
+
+
+setup(use_scm_version={"local_scheme": local_scheme})


### PR DESCRIPTION
For https://github.com/RonnyPfannschmidt/iniconfig/issues/17.

This will auto-deploy sdist and wheel to PyPI for tags, using GitHub Actions.

And to check the release mechanism is working, it deploys to TestPyPI for merges to master, to help avoid surprises on release day.

Uses PyPI [API tokens](https://pypi.org/help/#apitoken).

# Set up instructions

## TestPyPI

1. Go to https://test.pypi.org/manage/account/token/ and create a token called something like `iniconfig-ci` and give scope "Project: iniconfit"

<img width="50%" src="https://user-images.githubusercontent.com/1324225/96295694-bf40d280-0ff6-11eb-9a96-5a414e2c08a7.png">

2. Copy the token

3. Go to https://github.com/RonnyPfannschmidt/iniconfig/settings/secrets and save the token as `test_pypi_password`

## PyPI

4. Repeat for production PyPI: create token at https://pypi.org/manage/account/token/

5. Copy the token

6. Go to https://github.com/RonnyPfannschmidt/iniconfig/settings/secrets and save the token as `pypi_password`

