### PR TITLE
Fix autodeploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install -U pip
-          python -m pip install -U setuptools twine wheel
+          python -m pip install -U setuptools setuptools_scm twine wheel
 
       - name: Build package
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,7 +30,7 @@ jobs:
         python-version: ${{ matrix.python }}
     - name: Install tox
       run: |
-        python -m pip install --upgrade pip setuptools setuptools_scm
+        python -m pip install --upgrade pip setuptools
         pip install tox
     - name: Test
       run: |


### PR DESCRIPTION
Follow on from https://github.com/RonnyPfannschmidt/iniconfig/pull/20.

I'd put `setuptools_scm` in the wrong CI file in https://github.com/RonnyPfannschmidt/iniconfig/pull/20/commits/73f802bcbec58e8e4aafd753a057e1c956718ce6!