### PR TITLE
Ensure setuptools_scm is installed

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,8 @@
 from setuptools import setup
 
+# Ensures that setuptools_scm is installed, so wheels get proper versions
+import setuptools_scm  # noqa
+
 
 def local_scheme(version):
     """Skip the local version (eg. +xyz of 0.6.1.dev4+gdf99fe2)


### PR DESCRIPTION
If for some reason `setuptools_scm` isn't installed, `distutils` only warns a 

```
distutils/dist.py:274: UserWarning: Unknown distribution option: 'use_scm_version'
  warnings.warn(msg)
```

and versions the wheel as `0.0.0`.

This makes sure the package is installed, or `setup` will just fail.

Related to #17 